### PR TITLE
Modified listener to support different file-names and add new listener

### DIFF
--- a/android/android-xml-run-listener/src/main/java/de/schroepf/androidxmlrunlistener/XmlMultiReportRunListener.java
+++ b/android/android-xml-run-listener/src/main/java/de/schroepf/androidxmlrunlistener/XmlMultiReportRunListener.java
@@ -1,0 +1,45 @@
+package de.schroepf.androidxmlrunlistener;
+
+import android.app.Instrumentation;
+
+import org.xmlpull.v1.XmlSerializer;
+
+import java.io.File;
+
+/**
+ * This listener creates reports with unique file names (report-0.xml, report-1.xml ...), which
+ * is useful for running within a orchestrated setup where each test runs in a separate process.
+ *
+ * Note: It is necessary to clean up the report directory manually before running the orchestrator or
+ * previous files will persist.
+ *
+ * @see https://developer.android.com/training/testing/junit-runner.html#using-android-test-orchestrator
+ */
+public class XmlMultiReportRunListener extends XmlRunListener {
+
+    public XmlMultiReportRunListener() {
+        super();
+    }
+
+    public XmlMultiReportRunListener(XmlSerializer xmlSerializer) {
+        super(xmlSerializer);
+    }
+
+    @Override
+    protected String getFileName(Instrumentation instrumentation) {
+        return findFile("report", 0, ".xml", instrumentation);
+    }
+
+    private String findFile(String fileNamePrefix, int iterator, String fileNamePostfix, Instrumentation instr) {
+        String fileName = fileNamePrefix + "-" + iterator + fileNamePostfix;
+        File file = new File(instr.getTargetContext().getExternalFilesDir(null), fileName);
+
+        if (file.exists()) {
+            return findFile(fileNamePrefix, iterator + 1, fileNamePostfix, instr);
+        } else {
+            return file.getName();
+        }
+    }
+
+
+}

--- a/android/android-xml-run-listener/src/main/java/de/schroepf/androidxmlrunlistener/XmlRunListener.java
+++ b/android/android-xml-run-listener/src/main/java/de/schroepf/androidxmlrunlistener/XmlRunListener.java
@@ -61,7 +61,7 @@ public class XmlRunListener extends InstrumentationRunListener {
     public void setInstrumentation(Instrumentation instr) {
         super.setInstrumentation(instr);
 
-        final String fileName = "report.xml";
+        final String fileName = getFileName(instr);
 
         try {
             // Seems like we need to put this into the target application's context as for the instrumentation app's
@@ -83,6 +83,16 @@ public class XmlRunListener extends InstrumentationRunListener {
             Log.e(TAG, "Unable to open serializer", e);
             throw new RuntimeException("Unable to open serializer: " + e.getMessage(), e);
         }
+    }
+
+    /**
+     * Get a file for the test report. Override this to create different file patterns.
+     *
+     * @param instrumentation The current instrumentation with context
+     * @return A file name to write the report to
+     */
+    protected String getFileName(Instrumentation instrumentation) {
+        return "report.xml";
     }
 
     @Override


### PR DESCRIPTION
Change the way how to define the report file name in the XMLRunListener.
Override this behavior in the XmlMultiRunListner that creates
multiple report files for each run of the instrumentation.
This is especially useful for the Android Orchestrator test runner.