### PR TITLE
Migrate to androidX

### DIFF
--- a/android/android-xml-run-listener/build.gradle
+++ b/android/android-xml-run-listener/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'com.github.dcendents.android-maven'
 
 // This is the library version used when deploying the artifact
 group = "de.schroepf"
-version = "0.3.0"
+version = "0.3.1"
 
 def siteUrl = 'https://github.com/schroepf/TestLab/tree/master/android/android-xml-run-listener'
 def gitUrl = 'https://github.com/schroepf/TestLab'
@@ -115,7 +115,7 @@ bintray {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation ("com.android.support.test:runner:$test_runner_version") {
+    implementation ("androidx.test:runner:$test_runner_version") {
         exclude module: 'support-annotations'
     }
 

--- a/android/android-xml-run-listener/src/androidTest/java/de/schroepf/androidxmlrunlistener/ExampleInstrumentedTest.java
+++ b/android/android-xml-run-listener/src/androidTest/java/de/schroepf/androidxmlrunlistener/ExampleInstrumentedTest.java
@@ -1,6 +1,6 @@
 package de.schroepf.androidxmlrunlistener;
 
-import android.support.test.runner.AndroidJUnit4;
+import androidx.test.runner.AndroidJUnit4;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/android/android-xml-run-listener/src/main/java/de/schroepf/androidxmlrunlistener/XmlRunListener.java
+++ b/android/android-xml-run-listener/src/main/java/de/schroepf/androidxmlrunlistener/XmlRunListener.java
@@ -2,7 +2,6 @@ package de.schroepf.androidxmlrunlistener;
 
 import android.app.Instrumentation;
 import android.os.Build;
-import android.support.test.internal.runner.listener.InstrumentationRunListener;
 import android.util.Log;
 import android.util.Xml;
 
@@ -16,6 +15,8 @@ import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.Map;
+
+import androidx.test.internal.runner.listener.InstrumentationRunListener;
 
 /**
  * An InstrumentationRunListener which writes the test results to JUnit style XML files to the

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -15,7 +15,7 @@ buildscript {
     }
 
     ext {
-        test_runner_version = '1.0.2'
+        test_runner_version = '1.1.0'
         test_orchestrator_version = '1.0.2'
         android_xml_run_listener_version = '0.3.0'
     }

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -16,3 +16,5 @@
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
+android.enableJetifier=true
+android.useAndroidX=true

--- a/android/sampleapp/build.gradle
+++ b/android/sampleapp/build.gradle
@@ -11,12 +11,12 @@ android {
         versionCode 1
         versionName "1.0"
 
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         testInstrumentationRunnerArgument "listener", "de.schroepf.androidxmlrunlistener.XmlRunListener"
     }
 
     testOptions {
-        execution 'ANDROID_TEST_ORCHESTRATOR'
+        execution 'ANDROIDX_TEST_ORCHESTRATOR'
     }
 
     buildTypes {
@@ -33,23 +33,23 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'com.android.support:appcompat-v7:28.0.0'
-    implementation 'com.android.support:design:28.0.0'
-    implementation 'com.android.support:support-annotations:28.0.0'
+    implementation 'androidx.appcompat:appcompat:1.0.1'
+    implementation 'com.google.android.material:material:1.1.0-alpha01'
+    implementation 'androidx.annotation:annotation:1.0.0'
 
     testImplementation 'junit:junit:4.12'
 
     // use git version
-//    androidTestImplementation project(':android-xml-run-listener')
+    androidTestImplementation project(':android-xml-run-listener')
 
     // use published version
-    androidTestImplementation "de.schroepf:android-xml-run-listener:$android_xml_run_listener_version"
+    //androidTestImplementation "de.schroepf:android-xml-run-listener:$android_xml_run_listener_version"
 
     // Android Testing Support Library's runner and rules
-    androidTestImplementation ("com.android.support.test.espresso:espresso-core:3.0.1") {
+    androidTestImplementation ("androidx.test.espresso:espresso-core:3.1.0") {
         exclude module: 'support-annotations'
     }
 
-    androidTestImplementation "com.android.support.test:runner:$test_runner_version"
-    androidTestUtil "com.android.support.test:orchestrator:$test_orchestrator_version"
+    androidTestImplementation "androidx.test:runner:$test_runner_version"
+    androidTestUtil 'androidx.test:orchestrator:1.1.0'
 }

--- a/android/sampleapp/src/androidTest/java/de/schroepf/demoapp/AClass.java
+++ b/android/sampleapp/src/androidTest/java/de/schroepf/demoapp/AClass.java
@@ -1,6 +1,6 @@
 package de.schroepf.demoapp;
 
-import android.support.test.runner.AndroidJUnit4;
+import androidx.test.runner.AndroidJUnit4;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/android/sampleapp/src/androidTest/java/de/schroepf/demoapp/AnotherClass.java
+++ b/android/sampleapp/src/androidTest/java/de/schroepf/demoapp/AnotherClass.java
@@ -1,6 +1,6 @@
 package de.schroepf.demoapp;
 
-import android.support.test.runner.AndroidJUnit4;
+import androidx.test.runner.AndroidJUnit4;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/android/sampleapp/src/androidTest/java/de/schroepf/demoapp/ExampleInstrumentedTest.java
+++ b/android/sampleapp/src/androidTest/java/de/schroepf/demoapp/ExampleInstrumentedTest.java
@@ -1,8 +1,8 @@
 package de.schroepf.demoapp;
 
 import android.content.Context;
-import android.support.test.InstrumentationRegistry;
-import android.support.test.runner.AndroidJUnit4;
+import androidx.test.InstrumentationRegistry;
+import androidx.test.runner.AndroidJUnit4;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/android/sampleapp/src/androidTest/java/de/schroepf/demoapp/MainActivityTest.java
+++ b/android/sampleapp/src/androidTest/java/de/schroepf/demoapp/MainActivityTest.java
@@ -1,15 +1,15 @@
 package de.schroepf.demoapp;
 
-import android.support.test.runner.AndroidJUnit4;
+import androidx.test.runner.AndroidJUnit4;
 
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import static android.support.test.espresso.Espresso.onView;
-import static android.support.test.espresso.assertion.ViewAssertions.matches;
-import static android.support.test.espresso.matcher.ViewMatchers.withId;
-import static android.support.test.espresso.matcher.ViewMatchers.withText;
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
+import static androidx.test.espresso.matcher.ViewMatchers.withText;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;

--- a/android/sampleapp/src/main/java/de/schroepf/demoapp/MainActivity.java
+++ b/android/sampleapp/src/main/java/de/schroepf/demoapp/MainActivity.java
@@ -1,10 +1,10 @@
 package de.schroepf.demoapp;
 
 import android.os.Bundle;
-import android.support.design.widget.FloatingActionButton;
-import android.support.design.widget.Snackbar;
-import android.support.v7.app.AppCompatActivity;
-import android.support.v7.widget.Toolbar;
+import com.google.android.material.floatingactionbutton.FloatingActionButton;
+import com.google.android.material.snackbar.Snackbar;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.widget.Toolbar;
 import android.view.View;
 import android.view.Menu;
 import android.view.MenuItem;

--- a/android/sampleapp/src/main/res/layout/activity_main.xml
+++ b/android/sampleapp/src/main/res/layout/activity_main.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.design.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
@@ -7,23 +7,23 @@
     android:fitsSystemWindows="true"
     tools:context="de.schroepf.demoapp.MainActivity">
 
-    <android.support.design.widget.AppBarLayout
+    <com.google.android.material.appbar.AppBarLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:theme="@style/AppTheme.AppBarOverlay">
 
-        <android.support.v7.widget.Toolbar
+        <androidx.appcompat.widget.Toolbar
             android:id="@+id/toolbar"
             android:layout_width="match_parent"
             android:layout_height="?attr/actionBarSize"
             android:background="?attr/colorPrimary"
             app:popupTheme="@style/AppTheme.PopupOverlay" />
 
-    </android.support.design.widget.AppBarLayout>
+    </com.google.android.material.appbar.AppBarLayout>
 
     <include layout="@layout/content_main" />
 
-    <android.support.design.widget.FloatingActionButton
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
         android:id="@+id/fab"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
@@ -31,4 +31,4 @@
         android:layout_margin="@dimen/fab_margin"
         android:src="@android:drawable/ic_dialog_email" />
 
-</android.support.design.widget.CoordinatorLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>


### PR DESCRIPTION
The XmlRunListener does not work with projects using the new androidX packages. 

I run the migration tools from AS that changes the imports and dependencies.